### PR TITLE
feat: add view state persistence for filter preferences

### DIFF
--- a/src/components/dashboard/analysis/AnalysisHeader.tsx
+++ b/src/components/dashboard/analysis/AnalysisHeader.tsx
@@ -29,6 +29,9 @@ interface AnalysisHeaderProps {
   onSearchChange?: (search: string) => void
   onToggleUnreadOnly?: (enabled: boolean) => void
   onToggleHasUnsubscribe?: (enabled: boolean) => void
+  // Add current state props for proper display
+  showUnreadOnly?: boolean
+  showHasUnsubscribe?: boolean
 }
 
 export function AnalysisHeader({
@@ -42,14 +45,15 @@ export function AnalysisHeader({
   onBlockSenders = () => console.log('Block senders bulk action'),
   onSearchChange = () => console.log('Search changed'),
   onToggleUnreadOnly = () => console.log('Toggle unread only'),
-  onToggleHasUnsubscribe = () => console.log('Toggle has unsubscribe')
+  onToggleHasUnsubscribe = () => console.log('Toggle has unsubscribe'),
+  // Use props for current state instead of local state
+  showUnreadOnly = false,
+  showHasUnsubscribe = false
 }: AnalysisHeaderProps) {
   const hasSelection = selectedCount > 0;
   const { senders, isLoading, isAnalyzing } = useSenderData();
   const { exportToCSV, isExporting, error } = useExport();
   const [searchTerm, setSearchTerm] = useState('');
-  const [showUnreadOnly, setShowUnreadOnly] = useState(false);
-  const [showHasUnsubscribe, setShowHasUnsubscribe] = useState(false);
   
   // Loading states for filters
   const [isUnreadFilterLoading, setIsUnreadFilterLoading] = useState(false);
@@ -143,7 +147,6 @@ export function AnalysisHeader({
     requestAnimationFrame(() => {
       setTimeout(() => {
         const newValue = !showUnreadOnly;
-        setShowUnreadOnly(newValue);
         onToggleUnreadOnly(newValue);
       }, 0);
     });
@@ -159,7 +162,6 @@ export function AnalysisHeader({
     requestAnimationFrame(() => {
       setTimeout(() => {
         const newValue = !showHasUnsubscribe;
-        setShowHasUnsubscribe(newValue);
         onToggleHasUnsubscribe(newValue);
       }, 0);
     });

--- a/src/hooks/useViewState.ts
+++ b/src/hooks/useViewState.ts
@@ -1,0 +1,254 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react';
+import { logger } from '@/lib/utils/logger';
+
+// localStorage key for view state persistence
+const VIEW_STATE_KEY = 'mailmop-view-state';
+
+// Type definition for view state
+interface ViewState {
+  showUnreadOnly: boolean;
+  showHasUnsubscribe: boolean;
+  // Future extensibility for additional filters
+  searchTerm?: string;
+  sortField?: string;
+  sortDirection?: 'asc' | 'desc';
+}
+
+// Default view state
+const DEFAULT_VIEW_STATE: ViewState = {
+  showUnreadOnly: false,
+  showHasUnsubscribe: false,
+};
+
+// Valid view mode values for validation
+const VALID_BOOLEAN_KEYS = ['showUnreadOnly', 'showHasUnsubscribe'];
+
+/**
+ * Custom hook for managing view state with localStorage persistence
+ * 
+ * Features:
+ * - Automatically saves view state changes to localStorage
+ * - Restores view state on component mount
+ * - Handles localStorage unavailability gracefully
+ * - Validates stored values before applying them
+ * - Provides error handling and fallbacks
+ * 
+ * Usage:
+ * ```
+ * const { 
+ *   showUnreadOnly, 
+ *   showHasUnsubscribe, 
+ *   setShowUnreadOnly, 
+ *   setShowHasUnsubscribe 
+ * } = useViewState();
+ * ```
+ */
+export function useViewState() {
+  const [viewState, setViewState] = useState<ViewState>(DEFAULT_VIEW_STATE);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  // Helper function to check if localStorage is available
+  const isLocalStorageAvailable = useCallback((): boolean => {
+    try {
+      const test = '__localStorage_test__';
+      localStorage.setItem(test, test);
+      localStorage.removeItem(test);
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  // Helper function to validate stored view state
+  const validateViewState = useCallback((stored: any): ViewState => {
+    if (!stored || typeof stored !== 'object') {
+      logger.debug('Invalid stored view state, using defaults', { component: 'useViewState' });
+      return DEFAULT_VIEW_STATE;
+    }
+
+    const validated: ViewState = { ...DEFAULT_VIEW_STATE };
+
+    // Validate boolean fields
+    for (const key of VALID_BOOLEAN_KEYS) {
+      if (key in stored && typeof stored[key] === 'boolean') {
+        (validated as any)[key] = stored[key];
+      }
+    }
+
+    // Future: Add validation for additional fields like searchTerm, sortField, etc.
+    
+    return validated;
+  }, []);
+
+  // Load view state from localStorage on component mount
+  useEffect(() => {
+    if (!isLocalStorageAvailable()) {
+      logger.debug('localStorage not available, using default view state', { 
+        component: 'useViewState' 
+      });
+      setIsLoaded(true);
+      return;
+    }
+
+    try {
+      const storedViewState = localStorage.getItem(VIEW_STATE_KEY);
+      
+      if (storedViewState) {
+        const parsed = JSON.parse(storedViewState);
+        const validated = validateViewState(parsed);
+        
+        setViewState(validated);
+        
+        logger.debug('Restored view state from localStorage', { 
+          component: 'useViewState',
+          restored: validated 
+        });
+      } else {
+        logger.debug('No stored view state found, using defaults', { 
+          component: 'useViewState' 
+        });
+      }
+    } catch (error) {
+      logger.error('Error loading view state from localStorage', { 
+        component: 'useViewState', 
+        error: error instanceof Error ? error.message : String(error)
+      });
+      // Continue with default state on error
+    }
+    
+    setIsLoaded(true);
+  }, [isLocalStorageAvailable, validateViewState]);
+
+  // Save view state to localStorage whenever it changes
+  useEffect(() => {
+    // Don't save on initial load
+    if (!isLoaded) return;
+    
+    if (!isLocalStorageAvailable()) {
+      logger.debug('localStorage not available, skipping save', { 
+        component: 'useViewState' 
+      });
+      return;
+    }
+
+    try {
+      localStorage.setItem(VIEW_STATE_KEY, JSON.stringify(viewState));
+      
+      logger.debug('Saved view state to localStorage', { 
+        component: 'useViewState',
+        saved: viewState 
+      });
+    } catch (error) {
+      logger.error('Error saving view state to localStorage', { 
+        component: 'useViewState', 
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }, [viewState, isLoaded, isLocalStorageAvailable]);
+
+  // Listen for storage events to sync across tabs
+  useEffect(() => {
+    const handleStorageChange = (e: StorageEvent) => {
+      // Only handle our specific key
+      if (e.key !== VIEW_STATE_KEY) return;
+      
+      try {
+        if (e.newValue) {
+          const parsed = JSON.parse(e.newValue);
+          const validated = validateViewState(parsed);
+          setViewState(validated);
+          
+          logger.debug('Synced view state from another tab', { 
+            component: 'useViewState',
+            synced: validated 
+          });
+        } else {
+          // Key was removed, reset to defaults
+          setViewState(DEFAULT_VIEW_STATE);
+          logger.debug('View state cleared in another tab, resetting to defaults', { 
+            component: 'useViewState' 
+          });
+        }
+      } catch (error) {
+        logger.error('Error syncing view state from storage event', { 
+          component: 'useViewState',
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    };
+
+    // Only add listener if localStorage is available
+    if (isLocalStorageAvailable()) {
+      window.addEventListener('storage', handleStorageChange);
+      
+      return () => {
+        window.removeEventListener('storage', handleStorageChange);
+      };
+    }
+  }, [isLocalStorageAvailable, validateViewState]);
+
+  // Individual setters for easy component integration
+  const setShowUnreadOnly = useCallback((value: boolean) => {
+    setViewState(prev => ({ ...prev, showUnreadOnly: value }));
+  }, []);
+
+  const setShowHasUnsubscribe = useCallback((value: boolean) => {
+    setViewState(prev => ({ ...prev, showHasUnsubscribe: value }));
+  }, []);
+
+  // Future extensibility: additional setters can be added here
+  // const setSearchTerm = useCallback((value: string) => {
+  //   setViewState(prev => ({ ...prev, searchTerm: value }));
+  // }, []);
+
+  // Clear function for integration with user data clearing
+  const clearViewState = useCallback(() => {
+    if (!isLocalStorageAvailable()) return;
+    
+    try {
+      localStorage.removeItem(VIEW_STATE_KEY);
+      setViewState(DEFAULT_VIEW_STATE);
+      
+      logger.debug('Cleared view state', { component: 'useViewState' });
+    } catch (error) {
+      logger.error('Error clearing view state', { 
+        component: 'useViewState',
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }, [isLocalStorageAvailable]);
+
+  return {
+    // Current state values
+    showUnreadOnly: viewState.showUnreadOnly,
+    showHasUnsubscribe: viewState.showHasUnsubscribe,
+    
+    // Setters
+    setShowUnreadOnly,
+    setShowHasUnsubscribe,
+    
+    // Utility
+    isLoaded, // Indicates if localStorage has been checked and state restored
+    clearViewState, // For integration with user data clearing
+    
+    // Future extensibility
+    // searchTerm: viewState.searchTerm,
+    // setSearchTerm,
+  };
+}
+
+/**
+ * Utility function to clear view state from localStorage
+ * Can be called independently for cleanup scenarios
+ */
+export function clearStoredViewState(): void {
+  if (typeof window === 'undefined') return;
+  
+  try {
+    localStorage.removeItem(VIEW_STATE_KEY);
+  } catch (error) {
+    console.error('Error clearing stored view state:', error);
+  }
+} 

--- a/src/lib/storage/userStorage.ts
+++ b/src/lib/storage/userStorage.ts
@@ -1,4 +1,5 @@
 import { clearSenderAnalysis } from "./senderAnalysis";
+import { clearStoredViewState } from "@/hooks/useViewState";
 import { logger } from '@/lib/utils/logger';
 
 // Constants for localStorage keys
@@ -18,6 +19,9 @@ export async function clearAllUserData() {
   
   // Clear IndexedDB data
   await clearSenderAnalysis();
+  
+  // Clear view state (redundant after localStorage.clear(), but explicit for clarity)
+  clearStoredViewState();
 
   // Attempt to clear the HttpOnly session cookie by calling the revoke endpoint
   try {


### PR DESCRIPTION
Implements view state persistence to resolve GitHub issue #68. Users filter preferences (Unread Only, Has Unsubscribe) are now maintained across page refreshes. Features include cross-tab synchronization, automatic cleanup, graceful fallbacks, and comprehensive error handling. Closes #68